### PR TITLE
define serializer for target

### DIFF
--- a/notifications_rest/serializers.py
+++ b/notifications_rest/serializers.py
@@ -43,6 +43,7 @@ class NotificationSerializer(ModelSerializer):
     public = serializers.BooleanField()
     deleted = serializers.BooleanField()
     emailed = serializers.BooleanField()
+    target = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
 
     class Meta:
         model = Notification


### PR DESCRIPTION
Without this, the API returned error if target was defined. Now it will show target primary key.